### PR TITLE
Updates

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,12 +1,12 @@
 FROM gcr.io/google_appengine/base
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 # This is loosely based on the Dockerfile for the google/cloud-sdk image available
 # at https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
 
-ENV \
-	CACHE_BUST=4 \
-	CLOUDSDK_PYTHON_SITEPACKAGES=1 \
-	PATH="/google-cloud-sdk/bin:$PATH"
+ENV CACHE_BUST='2017-08-07' \
+		CLOUDSDK_PYTHON_SITEPACKAGES=1 \
+		PATH="/google-cloud-sdk/bin:${PATH}"
 
 RUN \
 	apt-get update && \

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:2.7-alpine
-MAINTAINER maintainers@codeship.com
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 # Check for the latest available version on
 # https://cloud.google.com/sdk/docs/#linux
-ARG GOOGLE_CLOUD_VERSION="157.0.0"
+ARG GOOGLE_CLOUD_VERSION="165.0.0"
 
-ENV PATH /google-cloud-sdk/bin:$PATH
+ENV PATH="/google-cloud-sdk/bin:${PATH}"
 
 RUN apk add --no-cache \
       bash \

--- a/dockercfg-generator/Dockerfile.test
+++ b/dockercfg-generator/Dockerfile.test
@@ -1,5 +1,5 @@
-FROM alpine:3.4
-MAINTAINER maintainers@codeship.com
+FROM alpine:3.6
+LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 RUN \
   echo "Hello ECR at $(date)" > hello.txt && \


### PR DESCRIPTION
* Update to latest versions of the Google Cloud SDK
* Update the “maintainer” label
* Update the test Docker image to use `alpine:3.6` as base image