### PR TITLE
Put ansible version var into role scope

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -9,6 +9,7 @@ RUN \
 RUN mkdir /root/bin
 
 COPY tasks /google-cloud/tasks
+COPY vars /google-cloud/vars
 COPY site.yml site.yml
 COPY deployment /google-cloud/deployment
 

--- a/site.yml
+++ b/site.yml
@@ -4,5 +4,3 @@
   - role: google-cloud
     gcloud_user: root
     gcloud_home: /root
-    gae_java_version: 1.9.64
-    gcloud_version: 204.0.0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+gae_java_version: 1.9.64
+gcloud_version: 204.0.0


### PR DESCRIPTION
This is mainly to single source variables and not need for us to specify the version again in other projects.