### PR TITLE
Update Python test dependencies

### DIFF
--- a/deployment/test-app-engine-python/requirements.txt
+++ b/deployment/test-app-engine-python/requirements.txt
@@ -1,2 +1,2 @@
-Flask==0.12.2
-gunicorn==19.7.1
+Flask==1.0.2
+gunicorn==19.9.0


### PR DESCRIPTION
GitHub is currently showing a dependency warning for flask. This should clear it up.