### PR TITLE
Update Go test app to Go 1.12

### DIFF
--- a/deployment/test-app-engine-go/app.yaml
+++ b/deployment/test-app-engine-go/app.yaml
@@ -1,6 +1,1 @@
-runtime: go
-api_version: go1
-
-handlers:
-- url: /.*
-  script: _go_app
+runtime: go112

--- a/deployment/test-app-engine-go/hello.go
+++ b/deployment/test-app-engine-go/hello.go
@@ -1,14 +1,29 @@
-package hello
+package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
+	"os"
 )
 
-func init() {
-	http.HandleFunc("/", handler)
+func main() {
+	http.HandleFunc("/", indexHandler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+
+	log.Printf("Listening on port %s", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }
 
-func handler(w http.ResponseWriter, r *http.Request) {
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
 	fmt.Fprint(w, "Hello, world!")
 }


### PR DESCRIPTION
Google modified the App Engine environment for Go, so the test app needed to be updated based on this guide:

https://cloud.google.com/appengine/docs/standard/go111/go-differences