### PR TITLE
Quiet down not-exactly-true unsupported warning for gcloud docker -a.

### DIFF
--- a/dockercfg-generator/gcr_docker_creds.sh
+++ b/dockercfg-generator/gcr_docker_creds.sh
@@ -13,7 +13,7 @@ gcloud auth activate-service-account "${GOOGLE_AUTH_EMAIL}" --key-file /keyconfi
 
 # Syncing credentials
 echo "Syncing GCR credentials"
-gcloud docker -a
+gcloud docker --verbosity=error -a
 
 echo "Writing Docker creds to $1"
 cat ~/.dockercfg > $1


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>